### PR TITLE
Auth pro /api/cron/cleanup přes CRON_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_or_eyJ...your-key-here
+
+# Vercel Cron auth — vygeneruj náhodný string (např. `openssl rand -hex 32`).
+# Vercel cron automaticky pošle `Authorization: Bearer <CRON_SECRET>` při každém volání.
+CRON_SECRET=replace-with-random-32-byte-hex

--- a/src/app/api/cron/cleanup/route.ts
+++ b/src/app/api/cron/cleanup/route.ts
@@ -2,7 +2,21 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 
 // Vercel Cron: soft-delete api_call_log řádky starší 30 dní.
-export async function GET() {
+// Vercel automaticky posílá `Authorization: Bearer <CRON_SECRET>`,
+// pokud je env CRON_SECRET nastavený. Lokálně volej s tím samým headerem.
+export async function GET(req: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: 'cron_secret_not_configured' },
+      { status: 500 },
+    );
+  }
+  const auth = req.headers.get('authorization');
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
   const supabase = await createClient();
   const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 


### PR DESCRIPTION
Closes #14

## Co se změnilo

- `/api/cron/cleanup` ověřuje `Authorization: Bearer ${CRON_SECRET}`. Bez headeru nebo s nesprávným secretem vrátí 401.
- Pokud `CRON_SECRET` env neexistuje, vrátí 500 (`cron_secret_not_configured`) — ať se to nezapomene nastavit.
- `.env.example` zdokumentován.

## Před mergem

Přidat `CRON_SECRET` env do Vercel projektu (Settings → Environment Variables, všechna prostředí). Vercel cron automaticky posílá `Authorization: Bearer <CRON_SECRET>` u každého volání.

Lokální test:
```bash
curl http://localhost:3001/api/cron/cleanup -H "Authorization: Bearer $CRON_SECRET"
```