### PR TITLE
feat: needs_review flow pro sporné modifikace faktur

### DIFF
--- a/migrations/002_resolution.sql
+++ b/migrations/002_resolution.sql
@@ -1,0 +1,30 @@
+-- 002_resolution.sql
+-- HYW — Sporná modifikace (S4): manuální review pro fakturu, která byla
+-- aktualizovaná ve Fakturoidu po importu. Účetní zapíše poznámku a označí
+-- jako resolved.
+--
+-- Migrace je idempotentní — lze ji bezpečně spustit opakovaně.
+
+-- Nové sloupce pro řešení sporných modifikací
+alter table invoice_imports
+  add column if not exists resolution_note text,
+  add column if not exists resolved_at     timestamptz,
+  add column if not exists resolved_by     uuid references auth.users(id);
+
+-- Rozšíření CHECK constraintu o nový status 'resolved'.
+-- DROP IF EXISTS + ADD je idempotentní: druhý běh dropne existující
+-- a vytvoří ho znovu se stejnou definicí.
+alter table invoice_imports drop constraint if exists invoice_imports_status_check;
+alter table invoice_imports add constraint invoice_imports_status_check
+  check (status in ('pending','success','failed','skipped','needs_review','resolved'));
+
+-- Partial CHECK: pokud je status 'resolved', resolution_note musí být
+-- not null a neprázdná po trimu. Vynucuje business pravidlo na DB úrovni.
+alter table invoice_imports drop constraint if exists invoice_imports_resolved_has_note;
+alter table invoice_imports add constraint invoice_imports_resolved_has_note
+  check (status <> 'resolved' or (resolution_note is not null and length(trim(resolution_note)) > 0));
+
+-- Index pro výpis vyřešených (řazeno podle resolved_at desc)
+create index if not exists idx_invoice_imports_resolved
+  on invoice_imports(resolved_at desc)
+  where status = 'resolved' and deleted_at is null;

--- a/src/app/api/webhooks/fakturoid/route.ts
+++ b/src/app/api/webhooks/fakturoid/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 // Stub webhook endpoint pro Fakturoid.
 // Skutečná akvizice (OAuth, GET detail, mapping) je v backlog.
 // Teď: přijmi payload, založ pending invoice_imports záznam, vrať 200.
+// Při duplicitě řeš sporné modifikace (S4) — flipni na needs_review.
 export async function POST(req: Request) {
   let payload: Record<string, unknown>;
   try {
@@ -29,6 +30,53 @@ export async function POST(req: Request) {
 
   const supabase = await createClient();
 
+  // 1. Zjisti, jestli už pro tento fakturoid_id máme živý záznam.
+  const { data: existing } = await supabase
+    .from('invoice_imports')
+    .select('id, status, deleted_at')
+    .eq('fakturoid_id', fakturoidId)
+    .is('deleted_at', null)
+    .maybeSingle();
+
+  // 2. Pokud existuje → větvíme podle status.
+  if (existing) {
+    const status = existing.status as string;
+
+    // success / pending → sporná modifikace, flipni na needs_review.
+    // Pozn.: dva souběžné webhooky si můžou navzájem přepsat fakturoid_snapshot
+    // (last-write-wins). Pro workshop MVP akceptováno; v produkci by se řešilo
+    // přes compare-and-swap (updated_at) nebo serializační queue.
+    if (status === 'success' || status === 'pending') {
+      const { error: updateError } = await supabase
+        .from('invoice_imports')
+        .update({
+          status: 'needs_review',
+          error_code: 'manual_review_required',
+          error_message:
+            'Faktura byla aktualizována ve Fakturoidu po importu — vyžaduje manuální kontrolu.',
+          fakturoid_snapshot: payload,
+        })
+        .eq('id', existing.id);
+
+      if (updateError) {
+        return NextResponse.json(
+          { error: updateError.message },
+          { status: 500 },
+        );
+      }
+
+      return NextResponse.json(
+        { ok: true, flagged_for_review: true, id: existing.id },
+        { status: 200 },
+      );
+    }
+
+    // failed → nech být, retry flow
+    // needs_review / resolved → už víme, neřešíme
+    return NextResponse.json({ ok: true, duplicate: true }, { status: 200 });
+  }
+
+  // 3. Neexistuje → INSERT nový pending záznam.
   const { data, error } = await supabase
     .from('invoice_imports')
     .insert({
@@ -42,7 +90,7 @@ export async function POST(req: Request) {
     .single();
 
   if (error) {
-    // Idempotence: unique constraint na fakturoid_id → "už máme"
+    // 4. Race condition: mezi SELECTem a INSERTem někdo stihl založit záznam.
     if (error.code === '23505') {
       return NextResponse.json({ ok: true, duplicate: true }, { status: 200 });
     }

--- a/src/app/imports/[id]/_components/resolve-form.tsx
+++ b/src/app/imports/[id]/_components/resolve-form.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+
+export function ResolveForm({ id }: { id: number }) {
+  const router = useRouter();
+  const [note, setNote] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = note.trim();
+    if (trimmed.length < 1) {
+      setError('Poznámka je povinná.');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from('invoice_imports')
+      .update({
+        status: 'resolved',
+        resolution_note: trimmed,
+        resolved_at: new Date().toISOString(),
+        error_code: null,
+      })
+      .eq('id', id);
+    if (error) {
+      setBusy(false);
+      setError(error.message);
+      return;
+    }
+    // Necháváme busy=true: router.refresh() doběhne asynchronně.
+    // Po refresh page.tsx form skryje (status už je 'resolved'),
+    // takže nepotřebujeme řešit reset stavu — zabraňuje to flickeru,
+    // kdy by byl form krátce zpátky enabled.
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <label
+        htmlFor={`resolution-note-${id}`}
+        className="block text-sm font-medium text-slate-700"
+      >
+        Poznámka k řešení
+      </label>
+      <textarea
+        id={`resolution-note-${id}`}
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        rows={3}
+        placeholder="Popiš, co jsi udělal/a (např. ručně upraveno v Pohodě, kontaktován klient…)"
+        className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+        disabled={busy}
+      />
+      <div className="flex flex-col items-start gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="submit"
+          disabled={busy}
+          className="inline-flex items-center rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {busy ? 'Pracuji…' : '✓ Označit jako vyřešeno'}
+        </button>
+        {error && <p className="text-xs text-rose-600">{error}</p>}
+      </div>
+    </form>
+  );
+}

--- a/src/app/imports/[id]/page.tsx
+++ b/src/app/imports/[id]/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { formatDateTime, statusBadgeClass } from '@/lib/format';
 import type { ApiCallLog, InvoiceImport } from '@/lib/supabase/types';
 import { RetryButton } from './_components/retry-button';
+import { ResolveForm } from './_components/resolve-form';
 
 export const dynamic = 'force-dynamic';
 
@@ -65,10 +66,43 @@ export default async function ImportDetailPage({
             · pokus #{item.attempt_count}
           </div>
         </div>
-        {(item.status === 'failed' || item.status === 'needs_review') && (
-          <RetryButton id={item.id} />
-        )}
+        {item.status === 'failed' && <RetryButton id={item.id} />}
       </header>
+
+      {item.status === 'needs_review' && (
+        <section className="space-y-3 rounded-lg border border-amber-300 bg-amber-50 p-4">
+          <div className="flex items-start gap-2">
+            <span aria-hidden className="text-xl leading-none">⚠</span>
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold text-amber-900">
+                Faktura vyžaduje manuální kontrolu
+              </h2>
+              {item.error_message && (
+                <p className="text-sm text-amber-900">{item.error_message}</p>
+              )}
+            </div>
+          </div>
+          <ResolveForm id={item.id} />
+        </section>
+      )}
+
+      {item.status === 'resolved' && (
+        <section className="space-y-2 rounded-lg border border-emerald-300 bg-emerald-50 p-4">
+          <div className="flex items-start gap-2">
+            <span aria-hidden className="text-xl leading-none">✓</span>
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold text-emerald-900">
+                Vyřešeno {formatDateTime(item.resolved_at)}
+              </h2>
+            </div>
+          </div>
+          {item.resolution_note && (
+            <pre className="overflow-auto whitespace-pre-wrap rounded border border-emerald-200 bg-white p-2 text-xs text-emerald-900">
+              {item.resolution_note}
+            </pre>
+          )}
+        </section>
+      )}
 
       <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <Field label="Pohoda ID" value={item.pohoda_id} />

--- a/src/app/imports/page.tsx
+++ b/src/app/imports/page.tsx
@@ -11,6 +11,7 @@ const STATUSES: (InvoiceImportStatus | 'all')[] = [
   'success',
   'failed',
   'needs_review',
+  'resolved',
   'skipped',
 ];
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -12,6 +12,7 @@ export function statusBadgeClass(status: string): string {
     'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium';
   switch (status) {
     case 'success':
+    case 'resolved':
       return `${base} bg-emerald-100 text-emerald-800`;
     case 'failed':
       return `${base} bg-rose-100 text-rose-800`;

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -23,7 +23,8 @@ export type InvoiceImportStatus =
   | 'success'
   | 'failed'
   | 'skipped'
-  | 'needs_review';
+  | 'needs_review'
+  | 'resolved';
 
 export type InvoiceImport = {
   id: number;
@@ -41,6 +42,9 @@ export type InvoiceImport = {
   fakturoid_snapshot: unknown;
   pohoda_request: string | null;
   pohoda_response: string | null;
+  resolution_note: string | null;
+  resolved_at: string | null;
+  resolved_by: string | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;


### PR DESCRIPTION
Implementace scénáře **S4 z PRD** — sporná modifikace už importované faktury.

## Flow

1. Fakturoid pošle webhook pro fakturu se stejným \`fakturoid_id\` jako existující záznam
2. Pokud existující status je \`success\` nebo \`pending\` → flipne na \`needs_review\` (neimportujeme znova do Pohody)
3. Admin vidí v \`/imports/<id>\` žlutý banner s textareou
4. Po vyplnění poznámky → status \`resolved\` (zelený banner)

## SQL migrace

\`\`\`sql
-- Spusť v DEV i PROD Supabase před mergi (idempotentní)
-- Obsah: migrations/002_resolution.sql
\`\`\`

Přidává: \`resolution_note\`, \`resolved_at\`, \`resolved_by\`, status \`resolved\`,
partial CHECK \`invoice_imports_resolved_has_note\`.

## Změny

- \`migrations/002_resolution.sql\` — idempotentní (drop+add constraints, if exists/if not exists)
- \`api/webhooks/fakturoid\` — select-then-update flow, komentář o last-write-wins race
- \`imports/[id]/page.tsx\` — amber/emerald bannery
- \`ResolveForm\` client component — validace, anti-flicker busy state
- \`InvoiceImportStatus\` rozšířen o \`resolved\`

## Test plán

- [ ] Spustit \`002_resolution.sql\` v DEV Supabase
- [ ] POST 2× na \`/api/webhooks/fakturoid\` se stejným \`invoice.id\` → druhý vytvoří needs_review
- [ ] Otevřít \`/imports/<id>\` → vyplnit poznámku → submit → status resolved
- [ ] Filtr \`needs_review\` a \`resolved\` na \`/imports\` funguje